### PR TITLE
Add README with setup instructions

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,60 @@
+# Codeground 백엔드
+
+이 저장소는 FastAPI 기반의 백엔드 서비스입니다. 인증 API를 제공하며 데이터베이스 마이그레이션을 위해 SQLAlchemy와 Alembic을 사용합니다.
+
+## 요구 사항
+
+- Python 3.11+
+- 의존성 관리를 위한 [Poetry](https://python-poetry.org/)
+- PostgreSQL 인스턴스
+
+## 설치
+
+1. **레포지토리 클론**
+
+   ```bash
+   git clone <repo-url>
+   cd Codeground-Backend
+   ```
+
+2. **의존성 설치**
+
+   Poetry로 프로젝트 의존성을 설치합니다:
+
+   ```bash
+   poetry install
+   ```
+
+3. **환경 변수 설정**
+
+   애플리케이션은 프로젝트 루트 **상위 디렉터리에** 위치한 `.env` 파일에서 변수를 로드합니다. 다음과 같이 `../.env` 파일을 생성합니다:
+
+   ```env
+   SECRET_KEY=your-secret-key
+   SECRET_KEY_AUTH=your-auth-key
+   DB_HOST=localhost
+   DB_USER=postgres
+   DB_PASSWORD=postgres
+   DB_NAME=codeground
+   ```
+
+   이 변수들은 PostgreSQL 연결 URL을 구성하는 데 사용됩니다.
+
+4. **데이터베이스 설정**
+
+   Alembic을 사용하여 데이터베이스를 초기화합니다. 마이그레이션 파일이 없다면 생성합니다:
+
+   ```bash
+   alembic revision --autogenerate -m "init"
+   alembic upgrade head
+   ```
+
+## 서비스 실행
+
+Uvicorn으로 FastAPI 애플리케이션을 실행합니다:
+
+```bash
+poetry run uvicorn src.app.main:app --reload
+```
+
+API는 `http://localhost:8000/`에서 확인할 수 있으며, 인증 엔드포인트는 `/api/v1` 로 시작합니다 (예: `/api/v1/auth/sign-up`).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Codeground Backend
+[한국어 README](README.ko.md)
+
 
 This repository contains a FastAPI based backend service. It provides authentication APIs and uses PostgreSQL through SQLAlchemy and Alembic for migrations.
 
@@ -58,4 +60,3 @@ poetry run uvicorn src.app.main:app --reload
 ```
 
 The API will be available at `http://localhost:8000/`. Authentication endpoints are prefixed with `/api/v1` (e.g. `/api/v1/auth/sign-up`).
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Codeground Backend
+
+This repository contains a FastAPI based backend service. It provides authentication APIs and uses PostgreSQL through SQLAlchemy and Alembic for migrations.
+
+## Requirements
+
+- Python 3.11+
+- [Poetry](https://python-poetry.org/) for dependency management
+- PostgreSQL instance
+
+## Installation
+
+1. **Clone the repository**
+
+   ```bash
+   git clone <repo-url>
+   cd Codeground-Backend
+   ```
+
+2. **Install dependencies**
+
+   Use Poetry to install the project requirements:
+
+   ```bash
+   poetry install
+   ```
+
+3. **Configure environment variables**
+
+   The application loads variables from a `.env` file located **one directory above** the project root. Create `../.env` relative to the repository with values similar to the following:
+
+   ```env
+   SECRET_KEY=your-secret-key
+   SECRET_KEY_AUTH=your-auth-key
+   DB_HOST=localhost
+   DB_USER=postgres
+   DB_PASSWORD=postgres
+   DB_NAME=codeground
+   ```
+
+   These variables are used to construct the database URL for PostgreSQL.
+
+4. **Database setup**
+
+   Initialize the database using Alembic. If no migration files exist, create one:
+
+   ```bash
+   alembic revision --autogenerate -m "init"
+   alembic upgrade head
+   ```
+
+## Running the Service
+
+Start the FastAPI application with Uvicorn:
+
+```bash
+poetry run uvicorn src.app.main:app --reload
+```
+
+The API will be available at `http://localhost:8000/`. Authentication endpoints are prefixed with `/api/v1` (e.g. `/api/v1/auth/sign-up`).
+


### PR DESCRIPTION
## Summary
- document project setup and service startup steps in a new README

## Testing
- `pre-commit run --files README.md` *(fails: pre-commit not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e9eed8c8832eb4d17ddb9b74a702