### PR TITLE
Implement screen share signaling

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -58,3 +58,10 @@ poetry run uvicorn src.app.main:app --reload
 ```
 
 API는 `http://localhost:8000/`에서 확인할 수 있으며, 인증 엔드포인트는 `/api/v1` 로 시작합니다 (예: `/api/v1/auth/sign-up`).
+
+## 스크린 공유
+
+WebRTC 시그널링을 위한 WebSocket 엔드포인트를 제공합니다. 클라이언트는
+`/api/v1/ws/screen-share/{room_id}` 경로로 접속하여 offer, answer, ICE candidate
+등의 메시지를 주고받을 수 있으며, 같은 방에 접속한 다른 사용자들에게 메시지가 전달됩니다.
+

--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ poetry run uvicorn src.app.main:app --reload
 ```
 
 The API will be available at `http://localhost:8000/`. Authentication endpoints are prefixed with `/api/v1` (e.g. `/api/v1/auth/sign-up`).
+
+## Screen Sharing
+
+The backend exposes a WebSocket endpoint for WebRTC signalling. Clients join a room using
+`/api/v1/ws/screen-share/{room_id}` and exchange offers, answers and ICE candidates.
+All messages sent to the server are relayed to the other participants in the same room.

--- a/src/app/domain/screenshare/__init__.py
+++ b/src/app/domain/screenshare/__init__.py
@@ -1,0 +1,6 @@
+from fastapi import APIRouter
+
+from .router import screenshare_controller
+
+router = APIRouter()
+router.include_router(screenshare_controller.router, prefix="/ws", tags=["screen-share"])

--- a/src/app/domain/screenshare/router/screenshare_controller.py
+++ b/src/app/domain/screenshare/router/screenshare_controller.py
@@ -1,0 +1,39 @@
+from typing import Dict, List
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+router = APIRouter()
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self.active_rooms: Dict[str, List[WebSocket]] = {}
+
+    async def connect(self, room: str, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_rooms.setdefault(room, []).append(websocket)
+
+    def disconnect(self, room: str, websocket: WebSocket) -> None:
+        if room in self.active_rooms:
+            self.active_rooms[room].remove(websocket)
+            if not self.active_rooms[room]:
+                del self.active_rooms[room]
+
+    async def broadcast(self, room: str, message: str, sender: WebSocket) -> None:
+        for ws in self.active_rooms.get(room, []):
+            if ws is not sender:
+                await ws.send_text(message)
+
+
+manager = ConnectionManager()
+
+
+@router.websocket("/screen-share/{room_id}")
+async def websocket_endpoint(websocket: WebSocket, room_id: str) -> None:
+    await manager.connect(room_id, websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await manager.broadcast(room_id, data, websocket)
+    except WebSocketDisconnect:
+        manager.disconnect(room_id, websocket)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.app.domain.auth import router as auth_router
+from src.app.domain.screenshare import router as screenshare_router
 from src.app.config.config import settings
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -26,6 +27,7 @@ app.add_middleware(
 )
 
 app.include_router(router=auth_router, prefix=settings.API_V1_STR)
+app.include_router(router=screenshare_router, prefix=settings.API_V1_STR)
 
 
 @app.get("/")
@@ -33,6 +35,5 @@ async def health_check():
     return JSONResponse({"status": "ok"})
 
 
-# test
 if __name__ == "__main__":
     uvicorn.run(app, host="127.0.0.1", port=8000)


### PR DESCRIPTION
## Summary
- add simple WebRTC signaling server under `screenshare` domain
- mount WebSocket router in `main.py`
- document `/api/v1/ws/screen-share/{room_id}` usage in English and Korean README

## Testing
- `pytest -q`
- `black --check src/app/domain/screenshare/router/screenshare_controller.py src/app/domain/screenshare/__init__.py src/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68590e0630b4832e94797fac2196fdba