### PR TITLE
Add WebRTC test frontend

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -58,3 +58,18 @@ poetry run uvicorn src.app.main:app --reload
 ```
 
 API는 `http://localhost:8000/`에서 확인할 수 있으며, 인증 엔드포인트는 `/api/v1` 로 시작합니다 (예: `/api/v1/auth/sign-up`).
+
+### WebRTC 시그널링
+
+CodeArena 서비스에서 플레이어들이 음성/영상 통화를 할 수 있도록 WebRTC 시그널링용
+WebSocket 엔드포인트를 제공합니다. 다음과 같이 접속합니다.
+
+```text
+/api/v1/ws/webrtc/<room>?username=<사용자명>
+```
+
+이 소켓으로 전송된 메시지는 같은 방의 다른 참가자들에게 브로드캐스트됩니다.
+
+### WebRTC 테스트 프론트엔드
+
+신호 기능을 간단히 시험해볼 수 있도록 `/static/webrtc_test.html` 경로에 예제 HTML 페이지가 포함되어 있습니다. 두 개의 브라우저에서 해당 페이지를 열고 동일한 방에 접속하면 화상 채팅을 확인할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,19 @@ poetry run uvicorn src.app.main:app --reload
 ```
 
 The API will be available at `http://localhost:8000/`. Authentication endpoints are prefixed with `/api/v1` (e.g. `/api/v1/auth/sign-up`).
+
+### WebRTC Signaling
+
+CodeArena provides a WebRTC signaling endpoint so players can negotiate peer-to-peer
+audio/video connections. Connect to the WebSocket endpoint using a room name and
+username:
+
+```text
+/api/v1/ws/webrtc/<room>?username=<your-name>
+```
+
+Any message sent over this socket will be broadcast to the other participants in the same room.
+
+### Sample WebRTC Frontend
+
+A minimal HTML page is provided at `/static/webrtc_test.html` to try out the signaling endpoint. Open this page in two different browsers and join the same room to establish a video chat.

--- a/src/app/domain/webrtc/__init__.py
+++ b/src/app/domain/webrtc/__init__.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+from .router import webrtc_controller
+
+router = APIRouter()
+router.include_router(webrtc_controller.router, prefix="/ws", tags=["webrtc"])

--- a/src/app/domain/webrtc/router/webrtc_controller.py
+++ b/src/app/domain/webrtc/router/webrtc_controller.py
@@ -1,0 +1,39 @@
+from typing import Dict, List
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+router = APIRouter()
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self.active_connections: Dict[str, List[WebSocket]] = {}
+
+    async def connect(self, room: str, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.setdefault(room, [])
+        self.active_connections[room].append(websocket)
+
+    def disconnect(self, room: str, websocket: WebSocket) -> None:
+        if room in self.active_connections:
+            self.active_connections[room].remove(websocket)
+            if not self.active_connections[room]:
+                del self.active_connections[room]
+
+    async def broadcast(self, room: str, message: str, sender: WebSocket) -> None:
+        for connection in self.active_connections.get(room, []):
+            if connection is not sender:
+                await connection.send_text(message)
+
+
+manager = ConnectionManager()
+
+
+@router.websocket("/webrtc/{room}")
+async def websocket_endpoint(websocket: WebSocket, room: str, username: str | None = None):
+    await manager.connect(room, websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await manager.broadcast(room, data, websocket)
+    except WebSocketDisconnect:
+        manager.disconnect(room, websocket)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.app.domain.auth import router as auth_router
+from src.app.domain.webrtc import router as webrtc_router
 from src.app.config.config import settings
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -26,6 +27,7 @@ app.add_middleware(
 )
 
 app.include_router(router=auth_router, prefix=settings.API_V1_STR)
+app.include_router(router=webrtc_router, prefix=settings.API_V1_STR)
 
 
 @app.get("/")

--- a/src/resource/static/webrtc_test.html
+++ b/src/resource/static/webrtc_test.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CodeArena WebRTC Test</title>
+    <style>
+        video { width: 45%; margin: 2%; background: #000; }
+    </style>
+</head>
+<body>
+    <h1>CodeArena WebRTC Test</h1>
+    <div>
+        <input id="room" placeholder="Room" />
+        <input id="name" placeholder="Username" />
+        <button id="join">Join</button>
+    </div>
+    <div>
+        <video id="localVideo" autoplay playsinline></video>
+        <video id="remoteVideo" autoplay playsinline></video>
+    </div>
+    <script>
+        let pc;
+        let ws;
+        document.getElementById('join').onclick = async () => {
+            const room = document.getElementById('room').value;
+            const name = document.getElementById('name').value;
+            if(!room) return alert('Room required');
+            ws = new WebSocket(`ws://${location.host}/api/v1/ws/webrtc/${room}?username=${encodeURIComponent(name)}`);
+            ws.onmessage = async ({ data }) => {
+                const msg = JSON.parse(data);
+                if (msg.type === 'offer') {
+                    await pc.setRemoteDescription(new RTCSessionDescription(msg));
+                    const answer = await pc.createAnswer();
+                    await pc.setLocalDescription(answer);
+                    ws.send(JSON.stringify(pc.localDescription));
+                } else if (msg.type === 'answer') {
+                    await pc.setRemoteDescription(new RTCSessionDescription(msg));
+                } else if (msg.type === 'candidate') {
+                    if (msg.candidate) {
+                        await pc.addIceCandidate(msg.candidate);
+                    }
+                }
+            };
+
+            const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+            document.getElementById('localVideo').srcObject = stream;
+            pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
+            stream.getTracks().forEach(track => pc.addTrack(track, stream));
+            pc.onicecandidate = ({ candidate }) => {
+                if (candidate) {
+                    ws.send(JSON.stringify({ type: 'candidate', candidate }));
+                }
+            };
+            pc.ontrack = (event) => {
+                document.getElementById('remoteVideo').srcObject = event.streams[0];
+            };
+            pc.onnegotiationneeded = async () => {
+                const offer = await pc.createOffer();
+                await pc.setLocalDescription(offer);
+                ws.send(JSON.stringify(pc.localDescription));
+            };
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide an HTML page under `/static/webrtc_test.html` that connects to the signaling server and opens a video chat
- document the new page in README and README.ko

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859147b9380832e8886ff765191df1e